### PR TITLE
Add use-cases to docs frontpage

### DIFF
--- a/frontend/src/routes/docs/rooc/+page.svelte
+++ b/frontend/src/routes/docs/rooc/+page.svelte
@@ -58,21 +58,49 @@
 
     <h1>Why Would You Use ROOC?</h1>
     <p>
-    Picture your team dealing with limited resources and an ever-growing workload. It's not long before you're searching for an SaaS like Linear app to help divide up the work and track overlap between responsibilities and problems.
+    Picture any scenario where you're faced with making the best of limited resources.
+    There any are number of domains where we often face these kind of decisions, but we'll start with a trip for groceries.
     </p>
     <p>
-    We often want to track such overlaps so that we can find two kinds of solutions:
+    You have a $50 store coupon and need to buy your groceries for the week. Your shopping list includes:
     </p>
-    <ol>
-        <li>Optimal minimum solution to help run as lean as possible in early stages.</li>
-        <li>Optimal maximum solution to reap the most benefits at mature stages.</li>
-    </ol>
+    <ul>
+         <li>
+         At least 3 fruits
+        </li>
+        <li>
+        At least 2 vegetables
+        </li>
+        <li>
+        At least 1 dairy product
+        </li>
+    </ul>
     <p>
-    Instead of paying for external service to crunch these solutions, you can think of ROOC as the toolkit to approach building your own in-house service.
+        Each item has a cost:
     </p>
-    <p>ROOC won't mockup the service for you, but its output gives you the common ground to help identify and agree on problems before committing to the work needed to try achieving an optimal outcome.
+    <ul>
+        <li>
+            Apples: $4
+        </li>
+        <li>
+            Bananas: $3
+        </li>
+        <li>
+            Carrots: $2
+        </li>
+        <li>
+            Spinach: $3
+        </li>
+        <li>
+            Milk: $5
+        </li>
+        <li>
+            Cheese: $6
+        </li>
+    </ul>
+    <p>
+        Your goal is to select items that meet the requirements and spend at least the full coupon, but you want to minimize spending more than the coupon value. ROOC can help you make your next move.
     </p>
-
     <h1>
         Contributing
     </h1>

--- a/frontend/src/routes/docs/rooc/+page.svelte
+++ b/frontend/src/routes/docs/rooc/+page.svelte
@@ -21,10 +21,28 @@
         ROOC documentation
     </h1>
     <p>
-        ROOC is a language designed to parse and convert formal optimization models into static formulations. These
-        static formulations can be transformed into linear models which can then be solved using optimization
-        techniques.
+        ROOC is a language designed to help you formalize problems, and prepares those problems in linear form to be solved. The ROOC environment
+        does this in 3 steps:
     </p>
+    <ol>
+        <li>
+        Compile-and-parse step helps formalize your problem into a pre-model (e.g. a LaTeX expression)
+        </li>
+        <li>
+        Transform step converts the formal problem into models you can revisit later.
+        </li>
+        <li>
+        Runtime step will run your linear model against solvers to find the optimal solution.
+        </li>
+    </ol>
+    <p>
+        You only need to focus on formalising your problem in the first step and the ROOC environment is able to handle the rest. You can always
+        revisit and revise your models later if needed.
+    </p>
+
+    <h1>
+        Getting started
+    </h1>
     <p>
         If you are looking for the typescript library documentation, look <a href={link}
                                                                              target="_blank"
@@ -34,13 +52,8 @@
         If you are looking for the rust library documentation, look <a href="https://docs.rs/rooc/latest/rooc/" target="_blank"
                                                                        style="color: var(--accent-10); text-decoration: underline">Here</a>
     </p>
-    <h1>
-        Getting started
-    </h1>
     <p>
-        To learn how ROOC works, follow those documentation pages, they will guide you through the syntax and how to
-        create
-        your own models.
+        These documentation pages are structured to help learn how ROOC works, guiding you through the syntax and how to create your own models.
     </p>
     <ul>
         <li>
@@ -56,6 +69,24 @@
             <a href="/docs/rooc/examples">Rooc examples</a>
         </li>
     </ul>
+
+    <h1>Why Would You Use ROOC?</h1>
+    <p>
+    Picture your team dealing with limited resources and an ever-growing workload. It's not long before you're searching for an SaaS like Linear app to help divide up the work and track overlap between responsibilities and problems.
+    </p>
+    <p>
+    We often want to track such overlaps so that we can find two kinds of solutions:
+    </p>
+    <ol>
+        <li>Optimal minimum solution to help run as lean as possible in early stages.</li>
+        <li>Optimal maximum solution to reap the most benefits at mature stages.</li>
+    </ol>
+    <p>
+    Instead of paying for external service to crunch these solutions, you can think of ROOC as the toolkit to approach building your own in-house service.
+    </p>
+    <p>ROOC won't mockup the service for you, but its output gives you the common ground to help identify and agree on problems before committing to the work needed to try achieving an optimal outcome.
+    </p>
+
     <h1>
         Contributing
     </h1>
@@ -64,6 +95,7 @@
             href="https://github.com/Specy/rooc" style="color: var(--accent-10); text-decoration: underline">Github</a>.
         <br/>
     </p>
+
     <h1>
         Limitations
     </h1>

--- a/frontend/src/routes/docs/rooc/+page.svelte
+++ b/frontend/src/routes/docs/rooc/+page.svelte
@@ -21,7 +21,7 @@
         ROOC documentation
     </h1>
     <p>
-        Rooc is a language designed to help you formalize problems and solve them through optimization models. You only need to focus on formalizing your problem to get started; the ROOC environment is able to handle the rest.
+        ROOC is a language designed to help you formalize problems and solve them through optimization models. You only need to focus on formalizing your problem to get started; the ROOC environment is able to handle the rest.
     </p>
     <p>
     You can always revisit and revise your models later if needed.

--- a/frontend/src/routes/docs/rooc/+page.svelte
+++ b/frontend/src/routes/docs/rooc/+page.svelte
@@ -21,25 +21,11 @@
         ROOC documentation
     </h1>
     <p>
-        ROOC is a language designed to help you formalize problems, and prepares those problems in linear form to be solved. The ROOC environment
-        does this in 3 steps:
+        Rooc is a language designed to help you formalize problems and solve them through optimization models. You only need to focus on formalizing your problem to get started; the ROOC environment is able to handle the rest.
     </p>
-    <ol>
-        <li>
-        Compile-and-parse step helps formalize your problem into a pre-model (e.g. a LaTeX expression)
-        </li>
-        <li>
-        Transform step converts the formal problem into models you can revisit later.
-        </li>
-        <li>
-        Runtime step will run your linear model against solvers to find the optimal solution.
-        </li>
-    </ol>
     <p>
-        You only need to focus on formalising your problem in the first step and the ROOC environment is able to handle the rest. You can always
-        revisit and revise your models later if needed.
+    You can always revisit and revise your models later if needed.
     </p>
-
     <h1>
         Getting started
     </h1>


### PR DESCRIPTION
This is partially addresses #16 and the task "Add section about what optimization is and why it's useful"

- Reworded the opening section explaining what ROOC does in simplified "3 steps" explanation
- Added a "Why Would You Use ROOC?" section for users who may want to immediately bridge the world of MILP optimization with how it's already bleeding into their real-world concerns. The example of using Linear app is based on the last lean startup I worked at.